### PR TITLE
Parse refactoring

### DIFF
--- a/src/kep/cfg.py
+++ b/src/kep/cfg.py
@@ -8,7 +8,7 @@ definitions.
                                                                   
 A parsing definition consists of:
  (a) parsing boundaries - start and end lines CSV file segment 
-     where defintion applies (self.markers)
+     where definition applies (self.markers)
  (b) a dictionary linking table headers ("Объем ВВП") and variable names 
      ("GDP")
  (с) reader function name, for some unusual tables.    
@@ -87,7 +87,7 @@ class Definition():
         # require occurence of varname, unit, eg 'GDP', 'rog'
         # only required variables will be imported to final dataset
         self.required.append((varname, unit))
-     
+
 class Specification:
     def __init__(self, pdef_main):
         self.main = pdef_main

--- a/src/kep/cfg.py
+++ b/src/kep/cfg.py
@@ -84,7 +84,7 @@ class Definition():
         return list(set(v for v in gen))
     
     def require(self, varname, unit):
-        # require occurence of varname, unit, eg 'GDP', 'rog'
+        # require occurrence of varname, unit, eg 'GDP', 'rog'
         # only required variables will be imported to final dataset
         self.required.append((varname, unit))
 

--- a/src/kep/parse.py
+++ b/src/kep/parse.py
@@ -254,6 +254,7 @@ class Table:
         self.header = Header(headers)
         self.datarows = datarows
         self.coln = max(row.len() for row in self.datarows)
+        self.splitter_func = None
 
     def parse(self, pdef, units):
         self.header.set_varname(pdef, units)
@@ -282,7 +283,7 @@ class Table:
             return make_label(vn, u)
 
     def is_defined(self):
-        return self.label and self.splitter_func
+        return bool(self.label and self.splitter_func)
 
     def echo_error_table_not_valid(self):
         if not self.label:
@@ -429,10 +430,9 @@ class DictMaker:
     def m_dict(self, val, m):
         return {**self.basedict, 'freq': 'm', 'value': to_float(val),
                 'month': m}
-        
+
     def __str__(self):
         return self.basedict.__str__()   
-        
 
 
 class Emitter:
@@ -524,6 +524,7 @@ def get_date_quarter_end(year, qtr):
 
 def get_date_year_end(year):
     return pd.Timestamp(date(year, 12, 31))
+
 
 class Frames:
     """Accepts Datapoints() instance and emits pandas DataFrames."""

--- a/src/kep/test_parse.py
+++ b/src/kep/test_parse.py
@@ -241,6 +241,10 @@ def test_Table_is_defined():
     table.splitter_func = splitter.SPECIAL_FUNC_NAMES_TO_FUNC_MAPPER['fiscal']
     assert table.is_defined() is True
 
+    # test tables from "TESTING END TO END" section
+    for table in tables:
+        assert table.is_defined() is True
+
 
 def all_values():
     # emit all values for debugging to_float()

--- a/src/kep/test_parse.py
+++ b/src/kep/test_parse.py
@@ -238,7 +238,7 @@ def test_Table_is_defined():
 
     # table has both label and splitter_func
     table = copy.deepcopy(TABLE)
-    table.splitter_func = splitter.SPECIAL_FUNC_NAMES_TO_FUNC_MAPPER['fiscal']
+    table.splitter_func = splitter.get_custom_splitter('fiscal')
     assert table.is_defined() is True
 
     # test tables from "TESTING END TO END" section

--- a/src/kep/test_parse.py
+++ b/src/kep/test_parse.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
+import copy
 
 import parse
 import files
+import splitter
 
 
 def test_get_date_funcs_return_pd_Timestamps():
@@ -228,6 +230,16 @@ varname: GDP, unit: rog
 ------------------
 1991 | 10 20 30 40
 ------------------"""
+
+
+def test_Table_is_defined():
+    # table has label, but misses splitter_func specified
+    assert TABLE.is_defined() is False
+
+    # table has both label and splitter_func
+    table = copy.deepcopy(TABLE)
+    table.splitter_func = splitter.SPECIAL_FUNC_NAMES_TO_FUNC_MAPPER['fiscal']
+    assert table.is_defined() is True
 
 
 def all_values():

--- a/src/kep/test_parse.py
+++ b/src/kep/test_parse.py
@@ -136,11 +136,6 @@ def test_Table_is_defined():
     table.splitter_func = splitter.get_custom_splitter('fiscal')
     assert table.is_defined() is True
 
-    # test tables from "TESTING END TO END" section
-    #for table in tables:
-    #    assert table.is_defined() is True
-
-
 # -----------------------------------------------------------------------------
 
 def test_csv_has_no_null_byte():


### PR DESCRIPTION
прошу замерджить.

из основного:
is_defined теперь возвращает строго бул, а не значение операнда, (на то он и is_* метод).
удобнее для проверок (см тест кейс в этом реквесте ниже).

self.splitter_func = None проинициализировал в конструкторе, иначе можно нарваться на эксепшн при вызове: 
` +        return bool(self.label and self.splitter_func) `

(self.splitter_func может быть не определена, пока не вызвали parse метод).
теперь это поправлено.

добавил тест метод на is_defined

ps: свежие изменения из мастера в ветку подтянул.