### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/src/frontpage/make_frontpage.py
+++ b/src/frontpage/make_frontpage.py
@@ -94,12 +94,12 @@ def spark(data):
 
 
 def spark_png_fn(varname):
-    return "%s_spark.png" % varname
+    return "{0!s}_spark.png".format(varname)
 
 
 def insert_image_to_md(name, folder=PNG_FOLDER):
     path = folder + "/" + spark_png_fn(name)
-    return '![](%s)' % path
+    return '![]({0!s})'.format(path)
 
 
 def stream_table_rows_images(dfm=dfm):

--- a/src/frontpage/old/frontpage.py
+++ b/src/frontpage/old/frontpage.py
@@ -99,11 +99,11 @@ def spark(data):
 def make_png_filename(vn, dirpath):
     if not os.path.exists(dirpath):
         os.makedirs(dirpath)
-    return os.path.join(dirpath, "%s_spark.png" % vn)
+    return os.path.join(dirpath, "{0!s}_spark.png".format(vn))
 
 
 def spark_png_fn(varname):
-    return "%s_spark.png" % varname
+    return "{0!s}_spark.png".format(varname)
 
 
 def write_sparkline_pngs(df, folder = config.PNG_FOLDER):
@@ -140,7 +140,7 @@ def get_last(df, lab):
 def insert_image_to_md(varname):
     folder = "https://github.com/epogrebnyak/data-rosstat-kep/raw/master/output/png/"
     path = folder + spark_png_fn(varname)
-    return '![](%s)' % path
+    return '![]({0!s})'.format(path)
   
 def get_md_code():
     header = ["Код", "Значение", "Дата", ""]

--- a/src/word/word.py
+++ b/src/word/word.py
@@ -178,7 +178,7 @@ def dump_doc_files_to_csv(file_list, csv_path):
     to_csv(folder_iter, csv_path)
 
 def make_file_list(folder):
-    files = ["tab.doc"] + ["tab%d.doc" % x for x in range(1, 5)]
+    files = ["tab.doc"] + ["tab{0:d}.doc".format(x) for x in range(1, 5)]
     return [os.path.abspath(os.path.join(folder, fn)) for fn in files]
 
 def folder_to_csv(folder):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:epogrebnyak:mini-kep?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:epogrebnyak:mini-kep?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)