### PR TITLE
""# FIXME: why to_float defaults to False and get_year to None?" resolved

### DIFF
--- a/src/kep/tables.py
+++ b/src/kep/tables.py
@@ -139,17 +139,17 @@ YEAR_CATCHER = re.compile('(\d{4}).*')
 
 def get_year(string: str, rx=YEAR_CATCHER):
     """Extracts year from string *string*.
-       Returns None if year is not valid or not in plausible range."""
+       Returns False if year is not valid or not in plausible range."""
     match = re.match(rx, string)
     if match:
         year = int(match.group(1))
         if year >= 1991:
             return year
-    return None
+    return False
 
 
 def is_year(string: str) -> bool:
-    return get_year(string) is not None
+    return get_year(string) is not False
 
 
 class Row:

--- a/src/kep/test_tables.py
+++ b/src/kep/test_tables.py
@@ -24,12 +24,12 @@ class Test_Function_get_year():
     def test_get_year(self):
         assert tables.get_year("19991)") == 1999
         assert tables.get_year("1999") == 1999
-        assert tables.get_year("1812") is None
+        assert tables.get_year("1812") is False
 
     def test_on_all_heads(self):
         for s in self.all_heads():
             year = tables.get_year(s)
-            assert isinstance(year, int) or year is None
+            assert isinstance(year, int) or year is False
 
     @staticmethod
     def all_heads():

--- a/src/kep/test_vintage.py
+++ b/src/kep/test_vintage.py
@@ -68,8 +68,6 @@ class Test_Functions_Dates():
         assert vintage.get_date_year_end(2015) == \
             pd.Timestamp('2015') + pd.offsets.YearEnd()
 
-# FIXME: why to_float defaults to False and get_year to None?
-
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Касаемо:

`# FIXME: why to_float defaults to False and get_year to None?`

Сделал единообразно, теперь обе ф-ции возвращают False в случае неудачи.

